### PR TITLE
Added some computed fields and a postgres view

### DIFF
--- a/hasura/metadata/databases/default/tables/public_survey_responses.yaml
+++ b/hasura/metadata/databases/default/tables/public_survey_responses.yaml
@@ -4,4 +4,29 @@ table:
 object_relationships:
 - name: survey
   using:
-    foreign_key_constraint_on: survey_id
+    manual_configuration:
+      column_mapping:
+        id: id
+      insertion_order: null
+      remote_table:
+        name: surveys
+        schema: public
+select_permissions:
+- permission:
+    columns:
+    - created_at
+    - id
+    - question_ids
+    - response_values
+    - wallet
+    filter: {}
+  role: anonymous
+- permission:
+    columns:
+    - created_at
+    - id
+    - question_ids
+    - response_values
+    - wallet
+    filter: {}
+  role: user

--- a/hasura/metadata/databases/default/tables/public_surveys.yaml
+++ b/hasura/metadata/databases/default/tables/public_surveys.yaml
@@ -16,6 +16,28 @@ array_relationships:
       table:
         name: questions
         schema: public
+- name: survey_responses
+  using:
+    manual_configuration:
+      column_mapping:
+        id: id
+      insertion_order: null
+      remote_table:
+        name: survey_responses
+        schema: public
+computed_fields:
+- comment: Gets the latest response timestamp for a given survey
+  definition:
+    function:
+      name: latest_response
+      schema: public
+  name: latest_response
+- comment: Will give the response count without having to do annoying processing on the front-end.
+  definition:
+    function:
+      name: response_count
+      schema: public
+  name: response_count
 insert_permissions:
 - permission:
     backend_only: false
@@ -44,6 +66,9 @@ select_permissions:
     - owner
     - title
     - updated_at
+    computed_fields:
+    - latest_response
+    - response_count
     filter:
       _or:
       - is_active:
@@ -63,6 +88,9 @@ select_permissions:
     - owner
     - title
     - updated_at
+    computed_fields:
+    - latest_response
+    - response_count
     filter:
       _or:
       - is_active:

--- a/hasura/metadata/databases/default/tables/tables.yaml
+++ b/hasura/metadata/databases/default/tables/tables.yaml
@@ -3,6 +3,7 @@
 - "!include public_question_type.yaml"
 - "!include public_questions.yaml"
 - "!include public_responses.yaml"
+- "!include public_survey_responses.yaml"
 - "!include public_surveys.yaml"
 - "!include public_token_types.yaml"
 - "!include public_users.yaml"

--- a/hasura/migrations/default/1649572248365_add_response_count_function/down.sql
+++ b/hasura/migrations/default/1649572248365_add_response_count_function/down.sql
@@ -1,0 +1,12 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- CREATE FUNCTION response_count(survey_row surveys)
+-- RETURNS BIGINT AS $$
+--   SELECT COUNT(DISTINCT public."responses".wallet)
+--   FROM public."surveys"
+--   LEFT JOIN public."questions"
+--   ON public."surveys".id=public."questions".survey_id
+--   LEFT JOIN public."responses"
+--   ON public."questions".id=public."responses".question_id
+--   WHERE public."surveys".id = survey_row.id;
+-- $$ LANGUAGE sql STABLE;

--- a/hasura/migrations/default/1649572248365_add_response_count_function/up.sql
+++ b/hasura/migrations/default/1649572248365_add_response_count_function/up.sql
@@ -1,0 +1,10 @@
+CREATE FUNCTION response_count(survey_row surveys)
+RETURNS BIGINT AS $$
+  SELECT COUNT(DISTINCT public."responses".wallet)
+  FROM public."surveys"
+  LEFT JOIN public."questions"
+  ON public."surveys".id=public."questions".survey_id
+  LEFT JOIN public."responses"
+  ON public."questions".id=public."responses".question_id
+  WHERE public."surveys".id = survey_row.id;
+$$ LANGUAGE sql STABLE;

--- a/hasura/migrations/default/1649574810075_add_survey_responses_view/down.sql
+++ b/hasura/migrations/default/1649574810075_add_survey_responses_view/down.sql
@@ -1,0 +1,10 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- CREATE OR REPLACE VIEW survey_responses AS
+-- SELECT public."responses".wallet, array_agg(public."responses".question_id) AS question_ids, array_agg(public."responses".response_content) AS response_values
+-- FROM public."surveys"
+-- LEFT JOIN public."questions"
+-- ON public."surveys".id=public."questions".survey_id
+-- LEFT JOIN public."responses"
+-- ON public."questions".id=public."responses".question_id
+-- GROUP BY public."responses".wallet;

--- a/hasura/migrations/default/1649574810075_add_survey_responses_view/up.sql
+++ b/hasura/migrations/default/1649574810075_add_survey_responses_view/up.sql
@@ -1,0 +1,8 @@
+CREATE OR REPLACE VIEW survey_responses AS
+SELECT public."responses".wallet, array_agg(public."responses".question_id) AS question_ids, array_agg(public."responses".response_content) AS response_values
+FROM public."surveys"
+LEFT JOIN public."questions"
+ON public."surveys".id=public."questions".survey_id
+LEFT JOIN public."responses"
+ON public."questions".id=public."responses".question_id
+GROUP BY public."responses".wallet;

--- a/hasura/migrations/default/1649575086161_add_survey_id_to_survey_responses/down.sql
+++ b/hasura/migrations/default/1649575086161_add_survey_id_to_survey_responses/down.sql
@@ -1,0 +1,10 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- CREATE OR REPLACE VIEW survey_responses AS
+-- SELECT public."responses".wallet, array_agg(public."responses".question_id) AS question_ids, array_agg(public."responses".response_content) AS response_values, public."surveys".id
+-- FROM public."surveys"
+-- LEFT JOIN public."questions"
+-- ON public."surveys".id=public."questions".survey_id
+-- LEFT JOIN public."responses"
+-- ON public."questions".id=public."responses".question_id
+-- GROUP BY (public."responses".wallet,public."surveys".id);

--- a/hasura/migrations/default/1649575086161_add_survey_id_to_survey_responses/up.sql
+++ b/hasura/migrations/default/1649575086161_add_survey_id_to_survey_responses/up.sql
@@ -1,0 +1,8 @@
+CREATE OR REPLACE VIEW survey_responses AS
+SELECT public."responses".wallet, array_agg(public."responses".question_id) AS question_ids, array_agg(public."responses".response_content) AS response_values, public."surveys".id
+FROM public."surveys"
+LEFT JOIN public."questions"
+ON public."surveys".id=public."questions".survey_id
+LEFT JOIN public."responses"
+ON public."questions".id=public."responses".question_id
+GROUP BY (public."responses".wallet,public."surveys".id);

--- a/hasura/migrations/default/1649576121135_add_latest_response_computer_field/down.sql
+++ b/hasura/migrations/default/1649576121135_add_latest_response_computer_field/down.sql
@@ -1,0 +1,14 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- CREATE OR REPLACE FUNCTION latest_response(survey_row surveys)
+-- RETURNS timestamptz as $$
+--     SELECT public."responses".created_at
+--     FROM public."surveys"
+--     LEFT JOIN public."questions"
+--     ON public."surveys".id=public."questions".survey_id
+--     LEFT JOIN public."responses"
+--     ON public."questions".id=public."responses".question_id
+--     WHERE public."surveys".id = survey_row.id
+--     ORDER BY public."responses".created_at DESC
+--     LIMIT 1;
+-- $$ LANGUAGE sql STABLE;

--- a/hasura/migrations/default/1649576121135_add_latest_response_computer_field/up.sql
+++ b/hasura/migrations/default/1649576121135_add_latest_response_computer_field/up.sql
@@ -1,0 +1,12 @@
+CREATE OR REPLACE FUNCTION latest_response(survey_row surveys)
+RETURNS timestamptz as $$
+    SELECT public."responses".created_at
+    FROM public."surveys"
+    LEFT JOIN public."questions"
+    ON public."surveys".id=public."questions".survey_id
+    LEFT JOIN public."responses"
+    ON public."questions".id=public."responses".question_id
+    WHERE public."surveys".id = survey_row.id
+    ORDER BY public."responses".created_at DESC
+    LIMIT 1;
+$$ LANGUAGE sql STABLE;

--- a/hasura/migrations/default/1649609491810_add_created_at_to_survey_responses/down.sql
+++ b/hasura/migrations/default/1649609491810_add_created_at_to_survey_responses/down.sql
@@ -1,0 +1,12 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- CREATE OR REPLACE VIEW "public"."survey_responses" AS
+--  SELECT responses.wallet,
+--     array_agg(responses.question_id) AS question_ids,
+--     array_agg(responses.response_content) AS response_values,
+--     surveys.id,
+--     responses.created_at
+--    FROM ((surveys
+--      LEFT JOIN questions ON ((surveys.id = questions.survey_id)))
+--      LEFT JOIN responses ON ((questions.id = responses.question_id)))
+--   GROUP BY responses.wallet, surveys.id, responses.created_at;

--- a/hasura/migrations/default/1649609491810_add_created_at_to_survey_responses/up.sql
+++ b/hasura/migrations/default/1649609491810_add_created_at_to_survey_responses/up.sql
@@ -1,0 +1,10 @@
+CREATE OR REPLACE VIEW "public"."survey_responses" AS 
+ SELECT responses.wallet,
+    array_agg(responses.question_id) AS question_ids,
+    array_agg(responses.response_content) AS response_values,
+    surveys.id,
+    responses.created_at
+   FROM ((surveys
+     LEFT JOIN questions ON ((surveys.id = questions.survey_id)))
+     LEFT JOIN responses ON ((questions.id = responses.question_id)))
+  GROUP BY responses.wallet, surveys.id, responses.created_at;

--- a/hasura/migrations/default/1649609594327_add_created_at_to_survey_responses/down.sql
+++ b/hasura/migrations/default/1649609594327_add_created_at_to_survey_responses/down.sql
@@ -1,0 +1,13 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- CREATE OR REPLACE VIEW "public"."survey_responses" AS
+--  SELECT responses.wallet,
+--     array_agg(responses.question_id) AS question_ids,
+--     array_agg(responses.response_content) AS response_values,
+--     surveys.id,
+--     responses.created_at
+--    FROM ((surveys
+--      LEFT JOIN questions ON ((surveys.id = questions.survey_id)))
+--      LEFT JOIN responses ON ((questions.id = responses.question_id)))
+--   GROUP BY responses.wallet, surveys.id, responses.created_at
+--   ORDER BY responses.created_at ASC;

--- a/hasura/migrations/default/1649609594327_add_created_at_to_survey_responses/up.sql
+++ b/hasura/migrations/default/1649609594327_add_created_at_to_survey_responses/up.sql
@@ -1,0 +1,11 @@
+CREATE OR REPLACE VIEW "public"."survey_responses" AS 
+ SELECT responses.wallet,
+    array_agg(responses.question_id) AS question_ids,
+    array_agg(responses.response_content) AS response_values,
+    surveys.id,
+    responses.created_at
+   FROM ((surveys
+     LEFT JOIN questions ON ((surveys.id = questions.survey_id)))
+     LEFT JOIN responses ON ((questions.id = responses.question_id)))
+  GROUP BY responses.wallet, surveys.id, responses.created_at
+  ORDER BY responses.created_at ASC;

--- a/hasura/migrations/default/1649610136987_run_sql_migration/down.sql
+++ b/hasura/migrations/default/1649610136987_run_sql_migration/down.sql
@@ -1,0 +1,13 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- CREATE OR REPLACE VIEW "public"."survey_responses" AS
+--  SELECT responses.wallet,
+--     array_agg(responses.question_id) AS question_ids,
+--     array_agg(responses.response_content) AS response_values,
+--     surveys.id,
+--     max(responses.created_at) as created_at
+--    FROM ((surveys
+--      LEFT JOIN questions ON ((surveys.id = questions.survey_id)))
+--      LEFT JOIN responses ON ((questions.id = responses.question_id)))
+--   GROUP BY responses.wallet, surveys.id
+--   ORDER BY created_at;

--- a/hasura/migrations/default/1649610136987_run_sql_migration/up.sql
+++ b/hasura/migrations/default/1649610136987_run_sql_migration/up.sql
@@ -1,0 +1,11 @@
+CREATE OR REPLACE VIEW "public"."survey_responses" AS 
+ SELECT responses.wallet,
+    array_agg(responses.question_id) AS question_ids,
+    array_agg(responses.response_content) AS response_values,
+    surveys.id,
+    max(responses.created_at) as created_at
+   FROM ((surveys
+     LEFT JOIN questions ON ((surveys.id = questions.survey_id)))
+     LEFT JOIN responses ON ((questions.id = responses.question_id)))
+  GROUP BY responses.wallet, surveys.id
+  ORDER BY created_at;


### PR DESCRIPTION
- Added come computed fields to the `surveys` table to make getting things like the response count and latest response easier.
- Also added a new postgres view called `survey_responses` which will aggregate responses by wallet on the server
  - _A note_: This may require some work later depending on how the shape of the responses change as we add things like multiple choice and tracking of token count/type etc
